### PR TITLE
feat: buffer gas constraints on l2 message validation thresholds

### DIFF
--- a/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
@@ -28,10 +28,6 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, ISemver {
     /// @custom:semver 2.4.0
     string public constant version = "2.4.0";
 
-    /// @notice Gas reserved for message validation within `passesDomainMessageValidator`
-    ///         of `relayMessage` in the L2CrossDomainMessenger.
-    uint64 public constant RELAY_MESSAGE_VALIDATOR_GAS = 50;
-
     /// @notice Constructs the L1CrossDomainMessenger contract.
     constructor() CrossDomainMessenger() {
         initialize({
@@ -81,10 +77,14 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, ISemver {
         return true;
     }
 
-    /// @notice Gas reserved for message validation within `passesDomainMessageValidator`
-    ///         of `relayMessage` in the L2CrossDomainMessenger.
-    function _relayMessageValidationGas() internal view virtual override returns (uint64) {
-        return RELAY_MESSAGE_VALIDATOR_GAS;
+    /// @inheritdoc CrossDomainMessenger
+    function _relayMessageValidationGas() internal pure override returns (uint64) {
+        return L1_RELAY_MESSAGE_VALIDATOR_GAS;
+    }
+
+    /// @inheritdoc CrossDomainMessenger
+    function _sendMessageValidationGas() internal pure override returns (uint64) {
+        return L2_RELAY_MESSAGE_VALIDATOR_GAS;
     }
 
     /// @notice Getter function for the OptimismPortal contract on this chain.

--- a/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
@@ -28,6 +28,10 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, ISemver {
     /// @custom:semver 2.4.0
     string public constant version = "2.4.0";
 
+    /// @notice Gas reserved for message validation within `passesDomainMessageValidator`
+    ///         of `relayMessage` in the L2CrossDomainMessenger.
+    uint64 public constant RELAY_MESSAGE_VALIDATOR_GAS = 50;
+
     /// @notice Constructs the L1CrossDomainMessenger contract.
     constructor() CrossDomainMessenger() {
         initialize({
@@ -75,6 +79,12 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, ISemver {
         returns (bool)
     {
         return true;
+    }
+
+    /// @notice Gas reserved for message validation within `passesDomainMessageValidator`
+    ///         of `relayMessage` in the L2CrossDomainMessenger.
+    function _relayMessageValidationGas() internal view virtual override returns (uint64) {
+        return RELAY_MESSAGE_VALIDATOR_GAS;
     }
 
     /// @notice Getter function for the OptimismPortal contract on this chain.

--- a/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
@@ -78,7 +78,7 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, ISemver {
     }
 
     /// @inheritdoc CrossDomainMessenger
-    function _relayMessageValidationGas(uint64 _messageLength) internal pure override returns (uint64) {
+    function _relayMessageValidationGas(uint64) internal pure override returns (uint64) {
         return L1_RELAY_MESSAGE_VALIDATOR_GAS;
     }
 

--- a/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
@@ -78,13 +78,13 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, ISemver {
     }
 
     /// @inheritdoc CrossDomainMessenger
-    function _relayMessageValidationGas() internal pure override returns (uint64) {
+    function _relayMessageValidationGas(uint64 messageLength) internal pure override returns (uint64) {
         return L1_RELAY_MESSAGE_VALIDATOR_GAS;
     }
 
     /// @inheritdoc CrossDomainMessenger
-    function _sendMessageValidationGas() internal pure override returns (uint64) {
-        return L2_RELAY_MESSAGE_VALIDATOR_GAS;
+    function _sendMessageValidationGas(uint64 messageLength) internal pure override returns (uint64) {
+        return _messageLengthValidationGas(messageLength) + L2_RELAY_MESSAGE_VALIDATOR_GAS;
     }
 
     /// @notice Getter function for the OptimismPortal contract on this chain.

--- a/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
@@ -78,13 +78,13 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, ISemver {
     }
 
     /// @inheritdoc CrossDomainMessenger
-    function _relayMessageValidationGas(uint64 messageLength) internal pure override returns (uint64) {
+    function _relayMessageValidationGas(uint64 _messageLength) internal pure override returns (uint64) {
         return L1_RELAY_MESSAGE_VALIDATOR_GAS;
     }
 
     /// @inheritdoc CrossDomainMessenger
-    function _sendMessageValidationGas(uint64 messageLength) internal pure override returns (uint64) {
-        return _messageLengthValidationGas(messageLength) + L2_RELAY_MESSAGE_VALIDATOR_GAS;
+    function _sendMessageValidationGas(uint64 _messageLength) internal pure override returns (uint64) {
+        return _messageLengthValidationGas(_messageLength) + L2_RELAY_MESSAGE_VALIDATOR_GAS;
     }
 
     /// @notice Getter function for the OptimismPortal contract on this chain.

--- a/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -96,7 +96,7 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
 
     /// @notice Gas reserved for message validation within `passesDomainMessageValidator`
     ///         of `relayMessage` in the L2CrossDomainMessenger.
-    function _relayMessageValidationGas() internal view override returns (uint64) {
+    function _relayMessageValidationGas() internal view virtual override returns (uint64) {
         return RELAY_MESSAGE_VALIDATOR_GAS;
     }
 

--- a/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -21,10 +21,6 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
     /// @custom:semver 2.1.0
     string public constant version = "2.1.0";
 
-    /// @notice Gas reserved for message validation within `passesDomainMessageValidator`
-    ///         of `relayMessage` in the L2CrossDomainMessenger.
-    uint64 public constant RELAY_MESSAGE_VALIDATOR_GAS = 25_500;
-
     /// @notice Constructs the L2CrossDomainMessenger contract.
     constructor() CrossDomainMessenger() {
         initialize({ _l1CrossDomainMessenger: CrossDomainMessenger(address(0)) });
@@ -70,14 +66,24 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
         override
         returns (bool)
     {
+        // Note: We are assuming that if message vaildation is active in the SystemConfig
+        //      the l1MessageValidator enforces the constraint that `_from` on the Deposit
+        //      is the L1CrossDomainMessenger.
+        //
+        // We make sure we only do validation on L1 -> L2 messages, otherwise
+        // this is a replay and should always be allowed.
+        if (!_isOtherMessenger()) {
+            return true;
+        }
+
         // TODO: Remove this comment 5_500 accounted for in this call.
         // Accounting for: Cold Sload (2100) + Cold Static (2600) = 4_700 + 800 (buffer extra logic)
         address l2MessageValidator = L1Block(Predeploys.L1_BLOCK_ATTRIBUTES).l2MessageValidator();
-
         if (l2MessageValidator == address(0)) {
             return true;
         }
 
+        // Check to make sure we have enough gas to continue, otherwise early exit.
         bytes memory callData = abi.encodeWithSelector(
             IL2MessageValidator(l2MessageValidator).validateMessage.selector,
             _nonce,
@@ -94,10 +100,14 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
         return success && abi.decode(returnData, (bool));
     }
 
-    /// @notice Gas reserved for message validation within `passesDomainMessageValidator`
-    ///         of `relayMessage` in the L2CrossDomainMessenger.
-    function _relayMessageValidationGas() internal view virtual override returns (uint64) {
-        return RELAY_MESSAGE_VALIDATOR_GAS;
+    /// @inheritdoc CrossDomainMessenger
+    function _relayMessageValidationGas() internal pure override returns (uint64) {
+        return L2_RELAY_MESSAGE_VALIDATOR_GAS;
+    }
+
+    /// @inheritdoc CrossDomainMessenger
+    function _sendMessageValidationGas() internal pure override returns (uint64) {
+        return L1_RELAY_MESSAGE_VALIDATOR_GAS;
     }
 
     /// @inheritdoc CrossDomainMessenger

--- a/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -76,8 +76,6 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
             return true;
         }
 
-        // TODO: Remove this comment 5_500 accounted for in this call.
-        // Accounting for: Cold Sload (2100) + Cold Static (2600) = 4_700 + 800 (buffer extra logic)
         address l2MessageValidator = L1Block(Predeploys.L1_BLOCK_ATTRIBUTES).l2MessageValidator();
         if (l2MessageValidator == address(0)) {
             return true;
@@ -93,8 +91,7 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
             _minGasLimit,
             _message
         );
-        // TODO: Decide what's a reasonable gas limit for this call.
-        // TODO: Remove comment - TOTAL: RELAY_MESSAGE_VALIDATOR_GAS: 5_500 + 20_000 = 25_500
+
         (bool success, bytes memory returnData) = l2MessageValidator.staticcall{ gas: 20_000 }(callData);
 
         return success && abi.decode(returnData, (bool));

--- a/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -66,13 +66,28 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
         override
         returns (bool)
     {
+        // TODO: Remove this comment 5_500 accounted for in this call.
+        // Accounting for: Cold Sload (2100) + Cold Static (2600) = 4_700 + 800 (buffer extra logic)
         address l2MessageValidator = L1Block(Predeploys.L1_BLOCK_ATTRIBUTES).l2MessageValidator();
+
         if (l2MessageValidator == address(0)) {
             return true;
         }
-        return IL2MessageValidator(l2MessageValidator).validateMessage(
-            _nonce, _sender, _target, _value, _minGasLimit, _message
+
+        bytes memory callData = abi.encodeWithSelector(
+            IL2MessageValidator(l2MessageValidator).validateMessage.selector,
+            _nonce,
+            _sender,
+            _target,
+            _value,
+            _minGasLimit,
+            _message
         );
+        // TODO: Decide what's a reasonable gas limit for this call.
+        // TODO: Remove comment - TOTAL: RELAY_MESSAGE_VALIDATOR_GAS: 5_500 + 20_000 = 25_500
+        (bool success, bytes memory returnData) = l2MessageValidator.staticcall{ gas: 20_000 }(callData);
+
+        return !success || !abi.decode(returnData, (bool));
     }
 
     /// @inheritdoc CrossDomainMessenger

--- a/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -91,7 +91,7 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
         // TODO: Remove comment - TOTAL: RELAY_MESSAGE_VALIDATOR_GAS: 5_500 + 20_000 = 25_500
         (bool success, bytes memory returnData) = l2MessageValidator.staticcall{ gas: 20_000 }(callData);
 
-        return !success || !abi.decode(returnData, (bool));
+        return success && abi.decode(returnData, (bool));
     }
 
     /// @notice Gas reserved for message validation within `passesDomainMessageValidator`

--- a/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -106,7 +106,7 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
     }
 
     /// @inheritdoc CrossDomainMessenger
-    function _sendMessageValidationGas(uint64 _messageLength) internal pure override returns (uint64) {
+    function _sendMessageValidationGas(uint64) internal pure override returns (uint64) {
         return L1_RELAY_MESSAGE_VALIDATOR_GAS;
     }
 

--- a/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -101,12 +101,12 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
     }
 
     /// @inheritdoc CrossDomainMessenger
-    function _relayMessageValidationGas(uint64 messageLength) internal pure override returns (uint64) {
-        return _messageLengthValidationGas(messageLength) + L2_RELAY_MESSAGE_VALIDATOR_GAS;
+    function _relayMessageValidationGas(uint64 _messageLength) internal pure override returns (uint64) {
+        return _messageLengthValidationGas(_messageLength) + L2_RELAY_MESSAGE_VALIDATOR_GAS;
     }
 
     /// @inheritdoc CrossDomainMessenger
-    function _sendMessageValidationGas(uint64 messageLength) internal pure override returns (uint64) {
+    function _sendMessageValidationGas(uint64 _messageLength) internal pure override returns (uint64) {
         return L1_RELAY_MESSAGE_VALIDATOR_GAS;
     }
 

--- a/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -21,6 +21,10 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
     /// @custom:semver 2.1.0
     string public constant version = "2.1.0";
 
+    /// @notice Gas reserved for message validation within `passesDomainMessageValidator`
+    ///         of `relayMessage` in the L2CrossDomainMessenger.
+    uint64 public constant RELAY_MESSAGE_VALIDATOR_GAS = 25_500;
+
     /// @notice Constructs the L2CrossDomainMessenger contract.
     constructor() CrossDomainMessenger() {
         initialize({ _l1CrossDomainMessenger: CrossDomainMessenger(address(0)) });
@@ -88,6 +92,12 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
         (bool success, bytes memory returnData) = l2MessageValidator.staticcall{ gas: 20_000 }(callData);
 
         return !success || !abi.decode(returnData, (bool));
+    }
+
+    /// @notice Gas reserved for message validation within `passesDomainMessageValidator`
+    ///         of `relayMessage` in the L2CrossDomainMessenger.
+    function _relayMessageValidationGas() internal view override returns (uint64) {
+        return RELAY_MESSAGE_VALIDATOR_GAS;
     }
 
     /// @inheritdoc CrossDomainMessenger

--- a/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -101,12 +101,12 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
     }
 
     /// @inheritdoc CrossDomainMessenger
-    function _relayMessageValidationGas() internal pure override returns (uint64) {
-        return L2_RELAY_MESSAGE_VALIDATOR_GAS;
+    function _relayMessageValidationGas(uint64 messageLength) internal pure override returns (uint64) {
+        return _messageLengthValidationGas(messageLength) + L2_RELAY_MESSAGE_VALIDATOR_GAS;
     }
 
     /// @inheritdoc CrossDomainMessenger
-    function _sendMessageValidationGas() internal pure override returns (uint64) {
+    function _sendMessageValidationGas(uint64 messageLength) internal pure override returns (uint64) {
         return L1_RELAY_MESSAGE_VALIDATOR_GAS;
     }
 

--- a/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
@@ -110,6 +110,14 @@ abstract contract CrossDomainMessenger is
     /// @notice Gas reserved for finalizing the execution of `relayMessage` after the safe call.
     uint64 public constant RELAY_RESERVED_GAS = 40_000;
 
+    /// @notice Gas reserved for message validation within `passesDomainMessageValidator`
+    ///         of `relayMessage`. For L1, this func MUST be a no-op.
+    uint64 public constant L1_RELAY_MESSAGE_VALIDATOR_GAS = 50;
+
+    /// @notice Gas reserved for message validation within `passesDomainMessageValidator`
+    ///         of `relayMessage` in the L2CrossDomainMessenger.
+    uint64 public constant L2_RELAY_MESSAGE_VALIDATOR_GAS = 25_500;
+
     /// @notice Gas reserved for the execution between the `hasMinGas` check and the external
     ///         call in `relayMessage`.
     uint64 public constant RELAY_GAS_CHECK_BUFFER = 5_000;
@@ -368,7 +376,9 @@ abstract contract CrossDomainMessenger is
         + RELAY_RESERVED_GAS
         // Gas reserved for the execution between the `hasMinGas` check and the `CALL`
         // opcode. (Conservative)
-        + RELAY_GAS_CHECK_BUFFER;
+        + RELAY_GAS_CHECK_BUFFER
+        // Gas reserved for message validation on the other domain
+        + _sendMessageValidationGas();
     }
 
     /// @notice Returns the address of the gas token and the token's decimals.
@@ -398,8 +408,12 @@ abstract contract CrossDomainMessenger is
         returns (bool);
 
     /// @notice Gas reserved for message validation within `passesDomainMessageValidator`
-    ///         of `relayMessage` in the L2CrossDomainMessenger.
-    function _relayMessageValidationGas() internal view virtual returns (uint64);
+    ///         of `relayMessage` in the CrossDomainMessenger.
+    function _relayMessageValidationGas() internal pure virtual returns (uint64);
+
+    /// @notice Gas reserved for message validation within `passesDomainMessageValidator`
+    ///         of `relayMessage` in the CrossDomainMessenger on the other chain.
+    function _sendMessageValidationGas() internal pure virtual returns (uint64);
 
     /// @notice Initializer.
     /// @param _otherMessenger CrossDomainMessenger contract on the other chain.

--- a/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/universal/CrossDomainMessenger.sol
@@ -423,10 +423,10 @@ abstract contract CrossDomainMessenger is
 
     /// @notice Computes a dynamic gas expansion overhead based on the length of the message
     ///         for message validation.
-    /// @param messageLength Length of the message.
+    /// @param _messageLength Length of the message.
     /// @return Dynamic gas expansion overhead.
-    function _messageLengthValidationGas(uint64 messageLength) internal pure returns (uint64) {
-        return messageLength * MIN_GAS_CALLDATA_OVERHEAD;
+    function _messageLengthValidationGas(uint64 _messageLength) internal pure returns (uint64) {
+        return _messageLength * MIN_GAS_CALLDATA_OVERHEAD;
     }
 
     /// @notice Initializer.


### PR DESCRIPTION
- Buffer min gas in `relayMessage` for L2 message validation
- Allocating `20_000` for static call to `l2MessageValidator`
- Allocating `5_500` for static call to `L1Block`