### PR TITLE
feat: use force replay controller for forced inclusion overriding

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -1002,7 +1002,7 @@ contract Deploy is Deployer {
                         gasPayingToken: customGasTokenAddress
                     }),
                     cfg.forceReplay(),
-                    cfg.censorshipFaultProver()
+                    cfg.forceReplayController()
                 )
             )
         });

--- a/packages/contracts-bedrock/scripts/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployConfig.s.sol
@@ -80,7 +80,7 @@ contract DeployConfig is Script {
     bool public useInterop;
 
     bool public forceReplay;
-    address public censorshipFaultProver;
+    address public forceReplayController;
 
     function read(string memory _path) public {
         console.log("DeployConfig: reading file %s", _path);
@@ -160,7 +160,7 @@ contract DeployConfig is Script {
         useInterop = _readOr(_json, "$.useInterop", false);
 
         forceReplay = _readOr(_json, "$.forceReplay", false);
-        censorshipFaultProver = _readOr(_json, "$.censorshipFaultProver", address(0));
+        forceReplayController = _readOr(_json, "$.forceReplayController", address(0));
     }
 
     function l1StartingBlockTag() public returns (bytes32) {
@@ -222,9 +222,9 @@ contract DeployConfig is Script {
         forceReplay = _forceReplay;
     }
 
-    /// @notice Allow the `censorshipFaultProver` config to be overridden in testing environments
-    function setCensorshipFaultProver(address _censorshipFaultProver) public {
-        censorshipFaultProver = _censorshipFaultProver;
+    /// @notice Allow the `forceReplayController` config to be overridden in testing environments
+    function setForceReplayController(address _forceReplayController) public {
+        forceReplayController = _forceReplayController;
     }
 
     function _getBlockByTag(string memory _tag) internal returns (bytes32) {

--- a/packages/contracts-bedrock/src/L1/IForceReplayController.sol
+++ b/packages/contracts-bedrock/src/L1/IForceReplayController.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.15;
+
+/// @title Contract to allow for bypassing of force replay enforcement.
+interface IForceReplayController {
+    /// @notice Returns a boolean indicating if the transaction should be force included.
+    /// @param _from Msg.sender of the L1 -> L2 message. This address is NOT aliased yet.
+    /// @param _to   The L1 -> L2 "to" field.
+    /// @param _mint The L1 -> L2 "_mint" field.
+    /// @param _value   The L1 -> L2 "_value" field.
+    /// @param _gasLimit   The L1 -> L2 "_gasLimit" field.
+    /// @param _isCreation   The L1 -> L2 "_isCreation" field.
+    /// @param _data   The L1 -> L2 "_data" field.
+    /// @return bool
+    function forceInclude(
+        address _from,
+        address _to,
+        uint256 _mint,
+        uint256 _value,
+        uint64 _gasLimit,
+        bool _isCreation,
+        bytes memory _data
+    )
+        external
+        view
+        returns (bool);
+}

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -152,7 +152,7 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken, IForceReplayCon
                 gasPayingToken: address(0)
             }),
             _forceReplay: false,
-            _censorshipFaultProver: address(0)
+            _forceReplayController: address(0)
         });
     }
 
@@ -169,7 +169,7 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken, IForceReplayCon
     ///                           canonical data.
     /// @param _addresses         Set of L1 contract addresses. These should be the proxies.
     /// @param _forceReplay       Initial force replay boolean value.
-    /// @param _censorshipFaultProver Initial censorship fault prover address value.
+    /// @param _forceReplayController Initial force replay controller address value.
     function initialize(
         address _owner,
         uint256 _overhead,
@@ -181,7 +181,7 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken, IForceReplayCon
         address _batchInbox,
         SystemConfig.Addresses memory _addresses,
         bool _forceReplay,
-        address _censorshipFaultProver
+        address _forceReplayController
     )
         public
         initializer
@@ -207,7 +207,7 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken, IForceReplayCon
         _setGasPayingToken(_addresses.gasPayingToken);
 
         _setForceReplay(_forceReplay);
-        _setCensorshipFaultProver(_censorshipFaultProver);
+        _setForceReplayController(_forceReplayController);
 
         _setResourceConfig(_config);
         require(_gasLimit >= minimumGasLimit(), "SystemConfig: gas limit too low");
@@ -312,16 +312,15 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken, IForceReplayCon
         return ForceReplay.getForceReplay();
     }
 
-    /// @notice Getter for the censorship fault prover address value.
-    function censorshipFaultProver() public view returns (address) {
-        return ForceReplay.getCensorshipFaultProver();
+    /// @notice Getter for the force replay controller address value.
+    function forceReplayController() public view returns (address) {
+        return ForceReplay.getForceReplayController();
     }
 
     /// @notice External setter for the force replay boolean value. Can only be called
     ///         by the owner or fault prover if being turned off.
     /// @param _forceReplay Boolean value for the force replay configuration.
-    function setForceReplay(bool _forceReplay) external {
-        require(owner() == _msgSender() || (!_forceReplay && msg.sender == ForceReplay.getCensorshipFaultProver()));
+    function setForceReplay(bool _forceReplay) external onlyOwner {
         _setForceReplay(_forceReplay);
     }
 
@@ -335,16 +334,16 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken, IForceReplayCon
         }
     }
 
-    /// @notice External setter for the censorship fault prover address. Can only be called by the owner.
-    /// @param _censorshipFaultProver Address value for the censorship fault prover.
-    function setCensorshipFaultProver(address _censorshipFaultProver) external onlyOwner {
-        _setCensorshipFaultProver(_censorshipFaultProver);
+    /// @notice External setter for the force replay controller address. Can only be called by the owner.
+    /// @param _forceReplayController Address value for the force replay controller.
+    function setForceReplayController(address _forceReplayController) external onlyOwner {
+        _setForceReplayController(_forceReplayController);
     }
 
-    /// @notice Internal setter for the censorship fault prover address value.
-    /// @param _censorshipFaultProver Address value for the censorship fault prover.
-    function _setCensorshipFaultProver(address _censorshipFaultProver) internal virtual {
-        ForceReplay.setCensorshipFaultProver(_censorshipFaultProver);
+    /// @notice Internal setter for the force replay controller address value.
+    /// @param _forceReplayController Address value for the force replay controller.
+    function _setForceReplayController(address _forceReplayController) internal virtual {
+        ForceReplay.setForceReplayController(_forceReplayController);
     }
 
     /// @notice Internal setter for the gas paying token address, includes validation.

--- a/packages/contracts-bedrock/src/libraries/ForceReplay.sol
+++ b/packages/contracts-bedrock/src/libraries/ForceReplay.sol
@@ -16,24 +16,24 @@ interface IForceReplayConfig {
 }
 
 /// @title ForceReplay
-/// @notice Handles reading and writing the force replay and censorship prover to storage.
+/// @notice Handles reading and writing the force replay and controller to storage.
 library ForceReplay {
     /// @notice The storage slot that contains the boolean for forceReplay
     bytes32 internal constant FORCE_REPLAY =
         bytes32(uint256(keccak256("opstack.forceReplay")) - 1);
 
-    /// @notice The storage slot that contains the address for the censorshipFaultProver
-    bytes32 internal constant CENSORSHIP_FAULT_PROVER =
-        bytes32(uint256(keccak256("opstack.censorshipFaultProver")) - 1);
+    /// @notice The storage slot that contains the address for the forceReplayController
+    bytes32 internal constant FORCE_REPLAY_CONTROLLER =
+        bytes32(uint256(keccak256("opstack.forceReplayController")) - 1);
 
     /// @notice Reads the FORCE_REPLAY bool from the magic storage slot.
     function getForceReplay() internal view returns (bool) {
         return Storage.getBool(FORCE_REPLAY);
     }
 
-    /// @notice Reads the CENSORSHIP_FAULT_PROVER address from the magic storage slot.
-    function getCensorshipFaultProver() internal view returns (address) {
-        return Storage.getAddress(CENSORSHIP_FAULT_PROVER);
+    /// @notice Reads the FORCE_REPLAY_CONTROLLER address from the magic storage slot.
+    function getForceReplayController() internal view returns (address) {
+        return Storage.getAddress(FORCE_REPLAY_CONTROLLER);
     }
 
     /// @notice Internal setter for the force replay boolean value.
@@ -41,8 +41,8 @@ library ForceReplay {
         Storage.setBool(FORCE_REPLAY, _forceReplay);
     }
 
-    /// @notice Internal setter for the censorship fault prover address value.
-    function setCensorshipFaultProver(address _censorshipFaultProver) internal {
-        Storage.setAddress(CENSORSHIP_FAULT_PROVER, _censorshipFaultProver);
+    /// @notice Internal setter for the force replay controller address value.
+    function setForceReplayController(address _forceReplayController) internal {
+        Storage.setAddress(FORCE_REPLAY_CONTROLLER, _forceReplayController);
     }
 }

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -144,7 +144,7 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 gasPayingToken: Constants.ETHER
             }),
             _forceReplay: false,
-            _censorshipFaultProver: address(0)
+            _forceReplayController: address(0)
         });
     }
 
@@ -176,7 +176,7 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 gasPayingToken: Constants.ETHER
             }),
             _forceReplay: false,
-            _censorshipFaultProver: address(0)
+            _forceReplayController: address(0)
         });
         assertEq(systemConfig.startBlock(), block.number);
     }
@@ -209,7 +209,7 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 gasPayingToken: Constants.ETHER
             }),
             _forceReplay: false,
-            _censorshipFaultProver: address(0)
+            _forceReplayController: address(0)
         });
         assertEq(systemConfig.startBlock(), 1);
     }
@@ -306,7 +306,7 @@ contract SystemConfig_Init_ResourceConfig is SystemConfig_Init {
                 gasPayingToken: address(0)
             }),
             _forceReplay: false,
-            _censorshipFaultProver: address(0)
+            _forceReplayController: address(0)
         });
     }
 }
@@ -346,7 +346,7 @@ contract SystemConfig_Init_CustomGasToken is SystemConfig_Init {
                 gasPayingToken: _gasPayingToken
             }),
             _forceReplay: false,
-            _censorshipFaultProver: address(0)
+            _forceReplayController: address(0)
         });
     }
 


### PR DESCRIPTION
- Replaces the `censorshipFaultProver` address with a `forcedReplayController` address.
- Static calls the `forcedReplayController` if `forceReplay` is turned on in order to allow for forced inclusion of a specific transaction based on logic in the controller.