### PR TITLE
Fir/v1.5.0

### DIFF
--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -1002,7 +1002,7 @@ contract Deploy is Deployer {
                         gasPayingToken: customGasTokenAddress
                     }),
                     cfg.forceReplay(),
-                    cfg.censorshipFaultProver()
+                    cfg.forceReplayController()
                 )
             )
         });

--- a/packages/contracts-bedrock/scripts/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/Deploy.s.sol
@@ -1000,7 +1000,9 @@ contract Deploy is Deployer {
                         optimismPortal: mustGetAddress("OptimismPortalProxy"),
                         optimismMintableERC20Factory: mustGetAddress("OptimismMintableERC20FactoryProxy"),
                         gasPayingToken: customGasTokenAddress
-                    })
+                    }),
+                    cfg.forceReplay(),
+                    cfg.censorshipFaultProver()
                 )
             )
         });

--- a/packages/contracts-bedrock/scripts/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployConfig.s.sol
@@ -79,6 +79,9 @@ contract DeployConfig is Script {
 
     bool public useInterop;
 
+    bool public forceReplay;
+    address public censorshipFaultProver;
+
     function read(string memory _path) public {
         console.log("DeployConfig: reading file %s", _path);
         try vm.readFile(_path) returns (string memory data) {
@@ -155,6 +158,9 @@ contract DeployConfig is Script {
         customGasTokenAddress = _readOr(_json, "$.customGasTokenAddress", address(0));
 
         useInterop = _readOr(_json, "$.useInterop", false);
+
+        forceReplay = _readOr(_json, "$.forceReplay", false);
+        censorshipFaultProver = _readOr(_json, "$.censorshipFaultProver", address(0));
     }
 
     function l1StartingBlockTag() public returns (bytes32) {
@@ -209,6 +215,16 @@ contract DeployConfig is Script {
     function setUseCustomGasToken(address _token) public {
         useCustomGasToken = true;
         customGasTokenAddress = _token;
+    }
+
+    /// @notice Allow the `forceReplay` config to be overridden in testing environments
+    function setForceReplay(bool _forceReplay) public {
+        forceReplay = _forceReplay;
+    }
+
+    /// @notice Allow the `censorshipFaultProver` config to be overridden in testing environments
+    function setCensorshipFaultProver(address _censorshipFaultProver) public {
+        censorshipFaultProver = _censorshipFaultProver;
     }
 
     function _getBlockByTag(string memory _tag) internal returns (bytes32) {

--- a/packages/contracts-bedrock/scripts/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployConfig.s.sol
@@ -80,7 +80,7 @@ contract DeployConfig is Script {
     bool public useInterop;
 
     bool public forceReplay;
-    address public censorshipFaultProver;
+    address public forceReplayController;
 
     function read(string memory _path) public {
         console.log("DeployConfig: reading file %s", _path);
@@ -160,7 +160,7 @@ contract DeployConfig is Script {
         useInterop = _readOr(_json, "$.useInterop", false);
 
         forceReplay = _readOr(_json, "$.forceReplay", false);
-        censorshipFaultProver = _readOr(_json, "$.censorshipFaultProver", address(0));
+        forceReplayController = _readOr(_json, "$.forceReplayController", address(0));
     }
 
     function l1StartingBlockTag() public returns (bytes32) {
@@ -222,9 +222,9 @@ contract DeployConfig is Script {
         forceReplay = _forceReplay;
     }
 
-    /// @notice Allow the `censorshipFaultProver` config to be overridden in testing environments
-    function setCensorshipFaultProver(address _censorshipFaultProver) public {
-        censorshipFaultProver = _censorshipFaultProver;
+    /// @notice Allow the `forceReplayController` config to be overridden in testing environments
+    function setForceReplayController(address _forceReplayController) public {
+        forceReplayController = _forceReplayController;
     }
 
     function _getBlockByTag(string memory _tag) internal returns (bytes32) {

--- a/packages/contracts-bedrock/src/L1/IForceReplayController.sol
+++ b/packages/contracts-bedrock/src/L1/IForceReplayController.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.15;
+
+/// @title Contract to allow for bypassing of force replay enforcement.
+interface IForceReplayController {
+    /// @notice Returns a boolean indicating if the transaction should be force included.
+    /// @param _from Msg.sender of the L1 -> L2 message. This address is NOT aliased yet.
+    /// @param _to   The L1 -> L2 "to" field.
+    /// @param _mint The L1 -> L2 "_mint" field.
+    /// @param _value   The L1 -> L2 "_value" field.
+    /// @param _gasLimit   The L1 -> L2 "_gasLimit" field.
+    /// @param _isCreation   The L1 -> L2 "_isCreation" field.
+    /// @param _data   The L1 -> L2 "_data" field.
+    /// @return bool
+    function forceInclude(
+        address _from,
+        address _to,
+        uint256 _mint,
+        uint256 _value,
+        uint64 _gasLimit,
+        bool _isCreation,
+        bytes memory _data
+    )
+        external
+        view
+        returns (bool);
+}

--- a/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
@@ -60,6 +60,11 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, ISemver {
         (_addr, _decimals) = systemConfig.gasPayingToken();
     }
 
+    /// @inheritdoc CrossDomainMessenger
+    function _xDomainRelayMessageForceReplayConfigGas() internal pure override returns (uint64) {
+        return RELAY_MESSAGE_FORCE_REPLAY_CONFIG_CALL_GAS;
+    }
+
     /// @notice Getter function for the OptimismPortal contract on this chain.
     ///         Public getter is legacy and will be removed in the future. Use `portal()` instead.
     /// @return Contract of the OptimismPortal on this chain.

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -22,11 +22,14 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken, IForceReplayCon
     /// @custom:value GAS_LIMIT            Represents an update to gas limit on L2.
     /// @custom:value UNSAFE_BLOCK_SIGNER  Represents an update to the signer key for unsafe
     ///                                    block distrubution.
+    /// @custom:value FORCE_REPLAY_CONTROLLER Represents an update to the force replay
+    ///                                       controller.
     enum UpdateType {
         BATCHER,
         GAS_CONFIG,
         GAS_LIMIT,
-        UNSAFE_BLOCK_SIGNER
+        UNSAFE_BLOCK_SIGNER,
+        FORCE_REPLAY_CONTROLLER
     }
 
     /// @notice Struct representing the addresses of L1 system contracts. These should be the
@@ -344,6 +347,8 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken, IForceReplayCon
     /// @param _forceReplayController Address value for the force replay controller.
     function _setForceReplayController(address _forceReplayController) internal virtual {
         ForceReplay.setForceReplayController(_forceReplayController);
+        bytes memory data = abi.encode(_forceReplayController);
+        emit ConfigUpdate(VERSION, UpdateType.FORCE_REPLAY_CONTROLLER, data);
     }
 
     /// @notice Internal setter for the gas paying token address, includes validation.

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -152,7 +152,7 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken, IForceReplayCon
                 gasPayingToken: address(0)
             }),
             _forceReplay: false,
-            _censorshipFaultProver: address(0)
+            _forceReplayController: address(0)
         });
     }
 
@@ -169,7 +169,7 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken, IForceReplayCon
     ///                           canonical data.
     /// @param _addresses         Set of L1 contract addresses. These should be the proxies.
     /// @param _forceReplay       Initial force replay boolean value.
-    /// @param _censorshipFaultProver Initial censorship fault prover address value.
+    /// @param _forceReplayController Initial force replay controller address value.
     function initialize(
         address _owner,
         uint256 _overhead,
@@ -181,7 +181,7 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken, IForceReplayCon
         address _batchInbox,
         SystemConfig.Addresses memory _addresses,
         bool _forceReplay,
-        address _censorshipFaultProver
+        address _forceReplayController
     )
         public
         initializer
@@ -207,7 +207,7 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken, IForceReplayCon
         _setGasPayingToken(_addresses.gasPayingToken);
 
         _setForceReplay(_forceReplay);
-        _setCensorshipFaultProver(_censorshipFaultProver);
+        _setForceReplayController(_forceReplayController);
 
         _setResourceConfig(_config);
         require(_gasLimit >= minimumGasLimit(), "SystemConfig: gas limit too low");
@@ -312,16 +312,15 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken, IForceReplayCon
         return ForceReplay.getForceReplay();
     }
 
-    /// @notice Getter for the censorship fault prover address value.
-    function censorshipFaultProver() public view returns (address) {
-        return ForceReplay.getCensorshipFaultProver();
+    /// @notice Getter for the force replay controller address value.
+    function forceReplayController() public view returns (address) {
+        return ForceReplay.getForceReplayController();
     }
 
     /// @notice External setter for the force replay boolean value. Can only be called
     ///         by the owner or fault prover if being turned off.
     /// @param _forceReplay Boolean value for the force replay configuration.
-    function setForceReplay(bool _forceReplay) external {
-        require(owner() == _msgSender() || (!_forceReplay && msg.sender == ForceReplay.getCensorshipFaultProver()));
+    function setForceReplay(bool _forceReplay) external onlyOwner {
         _setForceReplay(_forceReplay);
     }
 
@@ -335,16 +334,16 @@ contract SystemConfig is OwnableUpgradeable, ISemver, IGasToken, IForceReplayCon
         }
     }
 
-    /// @notice External setter for the censorship fault prover address. Can only be called by the owner.
-    /// @param _censorshipFaultProver Address value for the censorship fault prover.
-    function setCensorshipFaultProver(address _censorshipFaultProver) external onlyOwner {
-        _setCensorshipFaultProver(_censorshipFaultProver);
+    /// @notice External setter for the force replay controller address. Can only be called by the owner.
+    /// @param _forceReplayController Address value for the force replay controller.
+    function setForceReplayController(address _forceReplayController) external onlyOwner {
+        _setForceReplayController(_forceReplayController);
     }
 
-    /// @notice Internal setter for the censorship fault prover address value.
-    /// @param _censorshipFaultProver Address value for the censorship fault prover.
-    function _setCensorshipFaultProver(address _censorshipFaultProver) internal virtual {
-        ForceReplay.setCensorshipFaultProver(_censorshipFaultProver);
+    /// @notice Internal setter for the force replay controller address value.
+    /// @param _forceReplayController Address value for the force replay controller.
+    function _setForceReplayController(address _forceReplayController) internal virtual {
+        ForceReplay.setForceReplayController(_forceReplayController);
     }
 
     /// @notice Internal setter for the gas paying token address, includes validation.

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.15;
 import { ISemver } from "src/universal/ISemver.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { GasPayingToken, IGasToken } from "src/libraries/GasPayingToken.sol";
+import { ForceReplay, IForceReplayConfig } from "src/libraries/ForceReplay.sol";
 
 /// @custom:proxied
 /// @custom:predeploy 0x4200000000000000000000000000000000000015
@@ -12,9 +13,12 @@ import { GasPayingToken, IGasToken } from "src/libraries/GasPayingToken.sol";
 ///         Values within this contract are updated once per epoch (every L1 block) and can only be
 ///         set by the "depositor" account, a special system address. Depositor account transactions
 ///         are created by the protocol whenever we move to a new epoch.
-contract L1Block is ISemver, IGasToken {
+contract L1Block is ISemver, IGasToken, IForceReplayConfig {
     /// @notice Error returns when a non-depositor account tries to set L1 block values.
     error NotDepositor();
+
+    /// @notice Event emitted when force replay config is updated.
+    event ForceReplaySet(bool forceReplay);
 
     /// @notice Event emitted when the gas paying token is set.
     event GasPayingTokenSet(address indexed token, uint8 indexed decimals, bytes32 name, bytes32 symbol);
@@ -87,6 +91,12 @@ contract L1Block is ISemver, IGasToken {
     function isCustomGasToken() public view returns (bool) {
         (address token,) = gasPayingToken();
         return token != Constants.ETHER;
+    }
+
+    /// @notice Getter for the force replay boolean value. If nothing is in state, then it means
+    ///         forcing replay is off.
+    function isForcingReplay() public view returns (bool) {
+        return ForceReplay.getForceReplay();
     }
 
     /// @custom:legacy
@@ -163,5 +173,16 @@ contract L1Block is ISemver, IGasToken {
         GasPayingToken.set({ _token: _token, _decimals: _decimals, _name: _name, _symbol: _symbol });
 
         emit GasPayingTokenSet({ token: _token, decimals: _decimals, name: _name, symbol: _symbol });
+    }
+
+    /// @notice External setter for the force replay boolean value. Can only be called
+    ///         by the system depositor account.
+    /// @param _forceReplay The force replay boolean value to set.
+    function setForceReplay(bool _forceReplay) external {
+        if (msg.sender != DEPOSITOR_ACCOUNT()) revert NotDepositor();
+
+        ForceReplay.setForceReplay(_forceReplay);
+
+        emit ForceReplaySet(_forceReplay);
     }
 }

--- a/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L2/L2CrossDomainMessenger.sol
@@ -52,6 +52,16 @@ contract L2CrossDomainMessenger is CrossDomainMessenger, ISemver {
     }
 
     /// @inheritdoc CrossDomainMessenger
+    function _xDomainRelayMessageForceReplayConfigGas() internal pure override returns (uint64) {
+        return RELAY_MESSAGE_FORCE_REPLAY_CONFIG_NOOP_GAS;
+    }
+
+    /// @inheritdoc CrossDomainMessenger
+    function _relayMessageIsForcingReplay() internal view override returns (bool) {
+        return _isOtherMessenger() && L1Block(Predeploys.L1_BLOCK_ATTRIBUTES).isForcingReplay();
+    }
+
+    /// @inheritdoc CrossDomainMessenger
     function _isOtherMessenger() internal view override returns (bool) {
         return AddressAliasHelper.undoL1ToL2Alias(msg.sender) == address(otherMessenger);
     }

--- a/packages/contracts-bedrock/src/libraries/ForceReplay.sol
+++ b/packages/contracts-bedrock/src/libraries/ForceReplay.sol
@@ -16,24 +16,24 @@ interface IForceReplayConfig {
 }
 
 /// @title ForceReplay
-/// @notice Handles reading and writing the force replay and censorship prover to storage.
+/// @notice Handles reading and writing the force replay and controller to storage.
 library ForceReplay {
     /// @notice The storage slot that contains the boolean for forceReplay
     bytes32 internal constant FORCE_REPLAY =
         bytes32(uint256(keccak256("opstack.forceReplay")) - 1);
 
-    /// @notice The storage slot that contains the address for the censorshipFaultProver
-    bytes32 internal constant CENSORSHIP_FAULT_PROVER =
-        bytes32(uint256(keccak256("opstack.censorshipFaultProver")) - 1);
+    /// @notice The storage slot that contains the address for the forceReplayController
+    bytes32 internal constant FORCE_REPLAY_CONTROLLER =
+        bytes32(uint256(keccak256("opstack.forceReplayController")) - 1);
 
     /// @notice Reads the FORCE_REPLAY bool from the magic storage slot.
     function getForceReplay() internal view returns (bool) {
         return Storage.getBool(FORCE_REPLAY);
     }
 
-    /// @notice Reads the CENSORSHIP_FAULT_PROVER address from the magic storage slot.
-    function getCensorshipFaultProver() internal view returns (address) {
-        return Storage.getAddress(CENSORSHIP_FAULT_PROVER);
+    /// @notice Reads the FORCE_REPLAY_CONTROLLER address from the magic storage slot.
+    function getForceReplayController() internal view returns (address) {
+        return Storage.getAddress(FORCE_REPLAY_CONTROLLER);
     }
 
     /// @notice Internal setter for the force replay boolean value.
@@ -41,8 +41,8 @@ library ForceReplay {
         Storage.setBool(FORCE_REPLAY, _forceReplay);
     }
 
-    /// @notice Internal setter for the censorship fault prover address value.
-    function setCensorshipFaultProver(address _censorshipFaultProver) internal {
-        Storage.setAddress(CENSORSHIP_FAULT_PROVER, _censorshipFaultProver);
+    /// @notice Internal setter for the force replay controller address value.
+    function setForceReplayController(address _forceReplayController) internal {
+        Storage.setAddress(FORCE_REPLAY_CONTROLLER, _forceReplayController);
     }
 }

--- a/packages/contracts-bedrock/src/libraries/ForceReplay.sol
+++ b/packages/contracts-bedrock/src/libraries/ForceReplay.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Storage } from "src/libraries/Storage.sol";
+
+interface IOtherMessenger {
+    /// @notice Getter for the address of the messenger on the other domain.
+    function otherMessenger() external view returns (address);
+}
+
+/// @title IForceReplayConfig
+/// @notice Implemented by contracts that are aware of the force replay config.
+interface IForceReplayConfig {
+    /// @notice Returns true if the network is forcing L1 -> L2 replay for messages.
+    function isForcingReplay() external view returns (bool);
+}
+
+/// @title ForceReplay
+/// @notice Handles reading and writing the force replay and censorship prover to storage.
+library ForceReplay {
+    /// @notice The storage slot that contains the boolean for forceReplay
+    bytes32 internal constant FORCE_REPLAY =
+        bytes32(uint256(keccak256("opstack.forceReplay")) - 1);
+
+    /// @notice The storage slot that contains the address for the censorshipFaultProver
+    bytes32 internal constant CENSORSHIP_FAULT_PROVER =
+        bytes32(uint256(keccak256("opstack.censorshipFaultProver")) - 1);
+
+    /// @notice Reads the FORCE_REPLAY bool from the magic storage slot.
+    function getForceReplay() internal view returns (bool) {
+        return Storage.getBool(FORCE_REPLAY);
+    }
+
+    /// @notice Reads the CENSORSHIP_FAULT_PROVER address from the magic storage slot.
+    function getCensorshipFaultProver() internal view returns (address) {
+        return Storage.getAddress(CENSORSHIP_FAULT_PROVER);
+    }
+
+    /// @notice Internal setter for the force replay boolean value.
+    function setForceReplay(bool _forceReplay) internal {
+        Storage.setBool(FORCE_REPLAY, _forceReplay);
+    }
+
+    /// @notice Internal setter for the censorship fault prover address value.
+    function setCensorshipFaultProver(address _censorshipFaultProver) internal {
+        Storage.setAddress(CENSORSHIP_FAULT_PROVER, _censorshipFaultProver);
+    }
+}

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -144,7 +144,7 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 gasPayingToken: Constants.ETHER
             }),
             _forceReplay: false,
-            _censorshipFaultProver: address(0)
+            _forceReplayController: address(0)
         });
     }
 
@@ -176,7 +176,7 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 gasPayingToken: Constants.ETHER
             }),
             _forceReplay: false,
-            _censorshipFaultProver: address(0)
+            _forceReplayController: address(0)
         });
         assertEq(systemConfig.startBlock(), block.number);
     }
@@ -209,7 +209,7 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 gasPayingToken: Constants.ETHER
             }),
             _forceReplay: false,
-            _censorshipFaultProver: address(0)
+            _forceReplayController: address(0)
         });
         assertEq(systemConfig.startBlock(), 1);
     }
@@ -306,7 +306,7 @@ contract SystemConfig_Init_ResourceConfig is SystemConfig_Init {
                 gasPayingToken: address(0)
             }),
             _forceReplay: false,
-            _censorshipFaultProver: address(0)
+            _forceReplayController: address(0)
         });
     }
 }
@@ -346,7 +346,7 @@ contract SystemConfig_Init_CustomGasToken is SystemConfig_Init {
                 gasPayingToken: _gasPayingToken
             }),
             _forceReplay: false,
-            _censorshipFaultProver: address(0)
+            _forceReplayController: address(0)
         });
     }
 

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -142,7 +142,9 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 optimismPortal: address(0),
                 optimismMintableERC20Factory: address(0),
                 gasPayingToken: Constants.ETHER
-            })
+            }),
+            _forceReplay: false,
+            _censorshipFaultProver: address(0)
         });
     }
 
@@ -172,7 +174,9 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 optimismPortal: address(0),
                 optimismMintableERC20Factory: address(0),
                 gasPayingToken: Constants.ETHER
-            })
+            }),
+            _forceReplay: false,
+            _censorshipFaultProver: address(0)
         });
         assertEq(systemConfig.startBlock(), block.number);
     }
@@ -203,7 +207,9 @@ contract SystemConfig_Initialize_TestFail is SystemConfig_Initialize_Test {
                 optimismPortal: address(0),
                 optimismMintableERC20Factory: address(0),
                 gasPayingToken: Constants.ETHER
-            })
+            }),
+            _forceReplay: false,
+            _censorshipFaultProver: address(0)
         });
         assertEq(systemConfig.startBlock(), 1);
     }
@@ -298,7 +304,9 @@ contract SystemConfig_Init_ResourceConfig is SystemConfig_Init {
                 optimismPortal: address(0),
                 optimismMintableERC20Factory: address(0),
                 gasPayingToken: address(0)
-            })
+            }),
+            _forceReplay: false,
+            _censorshipFaultProver: address(0)
         });
     }
 }
@@ -336,7 +344,9 @@ contract SystemConfig_Init_CustomGasToken is SystemConfig_Init {
                 optimismPortal: address(optimismPortal),
                 optimismMintableERC20Factory: address(0),
                 gasPayingToken: _gasPayingToken
-            })
+            }),
+            _forceReplay: false,
+            _censorshipFaultProver: address(0)
         });
     }
 

--- a/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/L1/SystemConfig.t.sol
@@ -15,6 +15,7 @@ import { ResourceMetering } from "src/L1/ResourceMetering.sol";
 import { Proxy } from "src/universal/Proxy.sol";
 import { L1Block } from "src/L2/L1Block.sol";
 import { GasPayingToken } from "src/libraries/GasPayingToken.sol";
+import { ForceReplay } from "src/libraries/ForceReplay.sol";
 
 // Target contract
 import { SystemConfig } from "src/L1/SystemConfig.sol";
@@ -76,6 +77,11 @@ contract SystemConfig_Initialize_Test is SystemConfig_Init {
         (address token, uint8 decimals) = impl.gasPayingToken();
         assertEq(token, Constants.ETHER);
         assertEq(decimals, 18);
+        // Check force replay & controller
+        bool forceReplay = impl.isForcingReplay();
+        address forceReplayController = impl.forceReplayController();
+        assertEq(forceReplay, false);
+        assertEq(forceReplayController, address(0));
     }
 
     /// @dev Tests that initailization sets the correct values.
@@ -110,6 +116,11 @@ contract SystemConfig_Initialize_Test is SystemConfig_Init {
         (address token, uint8 decimals) = systemConfig.gasPayingToken();
         assertEq(token, Constants.ETHER);
         assertEq(decimals, 18);
+        // Check force replay & controller
+        bool forceReplay = systemConfig.isForcingReplay();
+        address forceReplayController = systemConfig.forceReplayController();
+        assertEq(forceReplay, false);
+        assertEq(forceReplayController, address(0));
     }
 }
 
@@ -468,6 +479,96 @@ contract SystemConfig_Init_CustomGasToken is SystemConfig_Init {
         );
 
         cleanStorageAndInit(address(token));
+    }
+}
+
+contract SystemConfig_Init_ForceReplay is SystemConfig_Init {
+    function setUp() public override {
+        super.enableForceReplay();
+        super.setUp();
+    }
+
+    /// @dev Helper to clean storage and then initialize the system config.
+    function cleanStorageAndInit(bool _forceReplay, address _forceReplayController) internal {
+        vm.store(address(systemConfig), bytes32(0), bytes32(0)); // initailizer
+        vm.store(address(systemConfig), ForceReplay.FORCE_REPLAY, bytes32(0));
+        vm.store(address(systemConfig), ForceReplay.FORCE_REPLAY_CONTROLLER, bytes32(0));
+
+        systemConfig.initialize({
+            _owner: alice,
+            _overhead: 2100,
+            _scalar: 1000000,
+            _batcherHash: bytes32(hex"abcd"),
+            _gasLimit: 30_000_000,
+            _unsafeBlockSigner: address(1),
+            _config: Constants.DEFAULT_RESOURCE_CONFIG(),
+            _batchInbox: address(0),
+            _addresses: SystemConfig.Addresses({
+                l1CrossDomainMessenger: address(0),
+                l1ERC721Bridge: address(0),
+                disputeGameFactory: address(0),
+                l1StandardBridge: address(0),
+                optimismPortal: address(optimismPortal),
+                optimismMintableERC20Factory: address(0),
+                gasPayingToken: address(0)
+            }),
+            _forceReplay: _forceReplay,
+            _forceReplayController: _forceReplayController
+        });
+    }
+
+    /// @dev Tests that initialization sets the correct values and getters work.
+    function test_initialize_forceReplay_succeeds() external view {
+        bool forceReplay = systemConfig.isForcingReplay();
+        assertEq(forceReplay, true);
+    }
+
+    /// @dev Tests that initialization sets the correct values and getters work for
+    /// force replay and controller.
+    function test_initialize_forceReplay_controller_succeeds() external view {
+        bool forceReplay = systemConfig.isForcingReplay();
+        assertEq(forceReplay, true);
+
+        address forceReplayController = systemConfig.forceReplayController();
+        assertEq(forceReplayController, address(0));
+    }
+
+    /// @dev Tests that initialization works for forceReplay with OptimismPortal.
+    function test_setForceReplay_forceReplay_succeeds() external {
+        cleanStorageAndInit(false, address(0));
+
+        vm.expectCall(
+            address(optimismPortal),
+            abi.encodeCall(optimismPortal.setForceReplay, (true))
+        );
+
+        vm.expectEmit(address(optimismPortal));
+        emit TransactionDeposited(
+            0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001,
+            Predeploys.L1_BLOCK_ATTRIBUTES,
+            0, // deposit version
+            abi.encodePacked(
+                uint256(0), // mint
+                uint256(0), // value
+                uint64(200_000), // gasLimit
+                false, // isCreation,
+                abi.encodeCall(L1Block.setForceReplay, (true))
+            )
+        );
+
+        cleanStorageAndInit(true, address(0));
+    }
+
+    /// @dev Tests that the config update event is emitted for forceReplayController
+    function test_setForceReplayController_forceReplay_succeeds() external {
+        cleanStorageAndInit(false, address(0));
+
+        address newController = address(100);
+
+        vm.expectEmit(address(systemConfig));
+        emit ConfigUpdate(0, SystemConfig.UpdateType.FORCE_REPLAY_CONTROLLER, abi.encode(newController));
+
+        cleanStorageAndInit(false, newController);
     }
 }
 

--- a/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
@@ -35,7 +35,9 @@ contract SystemConfig_GasLimitBoundaries_Invariant is Test {
                         optimismPortal: address(0),
                         optimismMintableERC20Factory: address(0),
                         gasPayingToken: Constants.ETHER
-                    })
+                    }),
+                    false, // force replay
+                    address(0) // censorship fault prover
                 )
             )
         );

--- a/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
+++ b/packages/contracts-bedrock/test/invariants/SystemConfig.t.sol
@@ -37,7 +37,7 @@ contract SystemConfig_GasLimitBoundaries_Invariant is Test {
                         gasPayingToken: Constants.ETHER
                     }),
                     false, // force replay
-                    address(0) // censorship fault prover
+                    address(0) // force replay controller
                 )
             )
         );

--- a/packages/contracts-bedrock/test/setup/CommonTest.sol
+++ b/packages/contracts-bedrock/test/setup/CommonTest.sol
@@ -22,6 +22,8 @@ contract CommonTest is Test, Setup, Events {
     bool useFaultProofs;
     address customGasToken;
     bool useInteropOverride;
+    bool forceReplay;
+    address forceReplayController;
 
     function setUp() public virtual override {
         alice = makeAddr("alice");
@@ -43,6 +45,12 @@ contract CommonTest is Test, Setup, Events {
         }
         if (useInteropOverride) {
             deploy.cfg().setUseInterop(true);
+        }
+        if (forceReplay) {
+            deploy.cfg().setForceReplay(true);
+        }
+        if (forceReplayController != address(0)) {
+            deploy.cfg().setForceReplayController(forceReplayController);
         }
 
         vm.etch(address(ffi), vm.getDeployedCode("FFIInterface.sol:FFIInterface"));
@@ -148,5 +156,25 @@ contract CommonTest is Test, Setup, Events {
         }
 
         useInteropOverride = true;
+    }
+
+    function enableForceReplay() public {
+        // Check if the system has already been deployed, based off of the heuristic that alice and bob have not been
+        // set by the `setUp` function yet.
+        if (!(alice == address(0) && bob == address(0))) {
+            revert("CommonTest: Cannot enable forceReplay after deployment. Consider overriding `setUp`.");
+        }
+
+        forceReplay = true;
+    }
+
+    function enableForceReplayController(address _forceReplayController) public {
+        // Check if the system has already been deployed, based off of the heuristic that alice and bob have not been
+        // set by the `setUp` function yet.
+        if (!(alice == address(0) && bob == address(0))) {
+            revert("CommonTest: Cannot enable forceReplayController after deployment. Consider overriding `setUp`.");
+        }
+
+        forceReplayController = _forceReplayController;
     }
 }

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -186,7 +186,9 @@ contract Initializer_Test is Bridge_Initializer {
                             optimismPortal: address(0),
                             optimismMintableERC20Factory: address(0),
                             gasPayingToken: Constants.ETHER
-                        })
+                        }),
+                        false,
+                        address(0)
                     )
                 ),
                 initializedSlotVal: deploy.loadInitializedSlot("SystemConfig")
@@ -222,7 +224,9 @@ contract Initializer_Test is Bridge_Initializer {
                             optimismPortal: address(0),
                             optimismMintableERC20Factory: address(0),
                             gasPayingToken: Constants.ETHER
-                        })
+                        }),
+                        false,
+                        address(0)
                     )
                 ),
                 initializedSlotVal: deploy.loadInitializedSlot("SystemConfigProxy")


### PR DESCRIPTION
This is a draft PR that shows the diff of the firewall contracts to the op-contracts release v1.5.0, whose commit was branched off with changes applied on top.

op-contracts release v1.5.0: https://github.com/ethereum-optimism/optimism/releases/tag/op-contracts%2Fv1.5.0